### PR TITLE
fixing-npm-package-vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20074,10 +20074,9 @@
       }
     },
     "node_modules/webpack/node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-      "license": "ISC",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -34772,9 +34771,9 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }


### PR DESCRIPTION
Upgraded ssri npm package from 6.0.1 to 6.0.2 
more on this here : https://snyk.io/vuln/npm:ssri%406.0.1